### PR TITLE
Terminology update

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -3,11 +3,11 @@
         <div class="powered_by">
             <div class="header">
                 <img src="@/assets/ava_logo_white.png" />
-                <h4>Powered by AVA</h4>
+                <h4>Powered by Avalanche</h4>
             </div>
             <p
                 class="ava_desc"
-            >The AVA Explorer is an analytics tool for Avalanche, an open-source platform for decentralized applications and the Internet of Finance.</p>
+            >The AVAX Explorer is an analytics tool for Avalanche, an open-source platform for decentralized applications and the Internet of Finance.</p>
             <img class="yeti" src="@/assets/yeti_footer.png" />
         </div>
         <div class="list">

--- a/src/views/Resources.vue
+++ b/src/views/Resources.vue
@@ -43,7 +43,7 @@
                     <h3>AVA-X</h3>
                     <p>Apply for grants to build on AVA.</p>
                     <div class="buts">
-                        <a href="https://www.avalabs.org/ava-x" target="_blank">Apply for Grants</a>
+                        <a href="https://www.avalabs.org/avalanche-x" target="_blank">Apply for Grants</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Replace link that redirects to direct link
Update terminology to use avalanche and ava-x in footer